### PR TITLE
feat: git diff option (and remove some alias)

### DIFF
--- a/config
+++ b/config
@@ -3,16 +3,9 @@
 	email = officel@users.noreply.github.com
 [alias]
        # short
-       b  = branch
-       ba = branch -a
        c  = commit
-       cv = commit -v
        co = checkout
        coo= checkout origin/master
-       di = diff
-       dc = diff --cached
-       f  = fetch --prune
-       st = status
        sw = switch
        swo= switch -d origin/master
 
@@ -52,3 +45,5 @@
 	defaultBranch = main
 [grep]
 	lineNumber = true
+[diff]
+	compactionHeuristic = true


### PR DESCRIPTION
```
git diff --compaction-heuristic
```

を常時有効。

branch, commit, diff, fetch, status の alias は使用頻度と
.dotfiles 側の aliases(bash alias) で git command とセットにしたので
git alias からは外すことにした。