### PR TITLE
feat: Commit signature verification

### DIFF
--- a/allowed_signers
+++ b/allowed_signers
@@ -1,0 +1,1 @@
+officel@users.noreply.github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOst8/Mo2OcFQRvi94lNe8pjMxOUh4BiW+NO60+ez0cG

--- a/config
+++ b/config
@@ -51,3 +51,5 @@
 	compactionHeuristic = true
 [gpg]
 	format = ssh
+[gpg "ssh"]
+	allowedSignersFile = /home/raki/.config/git/allowed_signers

--- a/config
+++ b/config
@@ -1,6 +1,7 @@
 [user]
 	name = Y.Nishimura
 	email = officel@users.noreply.github.com
+	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOst8/Mo2OcFQRvi94lNe8pjMxOUh4BiW+NO60+ez0cG
 [alias]
        # short
        c  = commit
@@ -47,3 +48,5 @@
 	lineNumber = true
 [diff]
 	compactionHeuristic = true
+[gpg]
+	format = ssh

--- a/config
+++ b/config
@@ -39,6 +39,7 @@
 [advice]
 	detachedHead = false
 [commit]
+	gpgsign = true
 	# template = /home/raki/.dotfiles/git_commit_conventions.txt
 [log]
 	follow = true


### PR DESCRIPTION
元のブログはこれ
https://github.blog/changelog/2022-08-23-ssh-commit-verification-now-supported/

ドキュメント
https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-verification

公開後すぐ試してうまくいかなかったんだけど、昼間何気にgithubを見ていたらローカルのログのところにマークが出現してるのを見てやりなおしてみた。