### PR TITLE
feat: ignore file .vault_password for ansible-vault

### DIFF
--- a/ignore
+++ b/ignore
@@ -7,3 +7,6 @@ terraform.tfstate
 terraform.tfstate.backup
 *.swp
 
+# ansible-vault password file in repo
+.vault_password
+


### PR DESCRIPTION
ansible-vault で使用するパスワードファイルを誤ってリポジトリに含めないように ignore に追加しておく

- ansible-vault のパスワードは平文のテキストファイルとして、環境変数 ANSIBLE_VAULT_PASSWORD_FILE で管理できる
- WSL 環境で実行権限がついた状態のファイルは ansible でスクリプトとして認識されてしまうため、リポジトリ外のネイティブディスクに保存、管理していた
- WSL 環境でファイル個別に権限を管理可能にする目途がついた（metadata処理が可能になった）ので、パスワードファイルをリポジトリと同じディレクトリに保存することにしたい
- 間違ってリポジトリに紛れ込まないようにグローバルで ignore しておく
- ちなみに ansible ではこのファイル名にはデフォルト値がない。個人的な命名であることに注意
- ansible-vault のパスワードをどのように管理するかはチームや組織で異なり、各自でファイル名を付けて管理するもの（それを .vault_password としただけ）
- ansible-vault を使用するリポジトリの vault パスワードはリポジトリ中の .vault_password ファイルに保存する、と覚えておけばよい