### PR TITLE
feat: my pre-commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ue -o pipefail
+export LC_ALL=C
+
+if type fortune > /dev/null 2>&1; then
+  # Yes, We Can!! w
+  fortune 100% jp_habit
+fi


### PR DESCRIPTION
ローカルで使ってる fortune が育ってきて、習慣作りに役に立ち始めたので
他のリポジトリにも設定しようと思って、global な位置に配置。

置いてあるだけでは使用されない。

グローバルにどうこうするためにあれこれやろうとするページも多いけど
余計な手間をかけたくないので簡単にやる。

- リポジトリにフックがないならシンボリックリンク貼ってしまえば OK

```bash
cd repo-dir
ln -s  ~/.config/git/hooks/pre-commit .git/hooks/pre-commit
```

- リポジトリにフックが既にあるなら呼び出しを追加

```bash
cat .git/hooks/pre-commit
#!/usr/bin/env bash

set -ue -o pipefail
export LC_ALL=C

# my global hook
source ~/.config/git/hooks/pre-commit

# ここから既存のフック（要は↑を既存のフックに追加）
```