### PR TITLE
fix: user.name

### DIFF
--- a/config
+++ b/config
@@ -1,5 +1,5 @@
 [user]
-	name = Y.Nishimura
+	name = NISHIMURA Yoshitaka
 	email = officel@users.noreply.github.com
 	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOst8/Mo2OcFQRvi94lNe8pjMxOUh4BiW+NO60+ez0cG
 [alias]


### PR DESCRIPTION
今更だけど[公用文等における日本人の姓名のローマ字表記に関する関係府省庁連絡会議](https://www.kantei.go.jp/jp/singi/seimei_romaji/index.html)の決定等の内容に基づいて、氏名の表記を姓－名の順にして、姓を大文字で表記するようにした。

GitHub 上の名前は修正してたけどローカルは対応してなかったので。