### PR TITLE
feat: ignore .act.secrets, .act.env

### DIFF
--- a/ignore
+++ b/ignore
@@ -10,3 +10,6 @@ terraform.tfstate.backup
 # ansible-vault password file in repo
 .vault_password
 
+# for act(github actions localy)
+.act.secrets
+.act.env


### PR DESCRIPTION
github actions をローカルでテストできる [act](https://github.com/nektos/act) について
この[記事](https://www.memory-lovers.blog/entry/2022/11/13/120000)に従って試してみたので、
secrets と env を ignore することにした。

デフォルトのベタなほうを使ってもいいんだけど、多数のリポジトリを扱ってると個別のバッティングが
面倒なことになる気がしたので分けておこうかなと。