### PR TITLE
fix: use --date=format-local

### DIFF
--- a/config
+++ b/config
@@ -18,7 +18,7 @@
 
 	# options
 	alias  = !git config --get-regexp 'alias\\.' | sed 's/alias\\.\\([^ ]*\\) \\(.*\\)/\\1\\\t => \\2/' | sort
-	plog   = log --pretty=format:'%C(yellow)%h %C(green)%cd %C(reset)%s %C(red)%d %C(cyan)[%an]' --date=format:'%t%Y/%m/%d %H:%M'  --all --graph
+	plog   = log --pretty=format:'%C(yellow)%h %C(green)%cd %C(reset)%s %C(red)%d %C(cyan)[%an]' --date=format-local:'%t%Y/%m/%d %H:%M'  --all --graph
 
 [core]
 	# editor = vim +15 +startinsert


### PR DESCRIPTION
普段はあんまり気にならないんだけど（そりゃそう。同じタイムゾーンの人と仕事してるから）
タイムゾーンを気にしないといけないなってなった。

他のタイムゾーンの人が投げたコミットの時刻表示

```
* ad4bfb7       2023/05/03 18:21 Update devcard.svg  (HEAD, origin/main, origin/HEAD) [github-actions[bot]]
* 3873623       2023/05/04 03:21 fix: timeout-minutes in workflow (#6)  [NISHIMURA Yoshitaka]
* da13a52       2023/04/30 13:16 Update devcard.svg  [github-actions[bot]]
```

format-local を使うとこうなる

```
* ad4bfb7       2023/05/04 03:21 Update devcard.svg  (HEAD, origin/main, origin/HEAD) [github-actions[bot]]
* 3873623       2023/05/04 03:21 fix: timeout-minutes in workflow (#6)  [NISHIMURA Yoshitaka]
* da13a52       2023/04/30 22:16 Update devcard.svg  [github-actions[bot]]
```