### PR TITLE
chore: ignore file name *.nogit

### DIFF
--- a/ignore
+++ b/ignore
@@ -7,6 +7,9 @@ terraform.tfstate
 terraform.tfstate.backup
 *.swp
 
+# temporary file
+*.nogit
+
 # ansible-vault password file in repo
 .vault_password
 


### PR DESCRIPTION
一時的にgitに含めないファイルを置いておきたい時に、拡張子を .nogit にすることで ignore させる。
リポジトリ毎に設定するの面倒だし自分の中でわかってればおｋ