### PR TITLE
feat: alias deleted & restoring. restore deleted files

### DIFF
--- a/config
+++ b/config
@@ -20,6 +20,9 @@
 	alias  = !git config --get-regexp 'alias\\.' | sed 's/alias\\.\\([^ ]*\\) \\(.*\\)/\\1\\\t => \\2/' | sort
 	plog   = log --pretty=format:'%C(yellow)%h %C(green)%cd %C(reset)%s %C(red)%d %C(cyan)[%an]' --date=format-local:'%t%Y/%m/%d %H:%M'  --all --graph
 
+	deleted = log --diff-filter=D --summary
+	restoring = !git checkout $(git rev-list -n 1 HEAD -- "${1:-none}")~1 --
+
 [core]
 	# editor = vim +15 +startinsert
 	editor = vim +startinsert


### PR DESCRIPTION
以前にリポジトリから削除したり移動したりしたファイルを探して復元したい要件があったので調べて alias にした。

```bash
# そのまま使うと削除処理があったコミットがリストされる
git deleted

# ファイルを渡すとそのファイルが削除されたコミットがわかる
git deleted -- FILENAME

# 削除済のファイルを探す。引数を渡さなかった場合は abort
git restoring FILENAME

# 復元できるとステージングされているので外す（restore で削除済ファイルを復元できるといいのに）
git restore --staged FILENAME
```