### PR TITLE
fix: git config diff.wsErrorHighlight all

### DIFF
--- a/config
+++ b/config
@@ -53,6 +53,7 @@
 	lineNumber = true
 [diff]
 	compactionHeuristic = true
+	wsErrorHighlight = all
 [gpg]
 	format = ssh
 [gpg "ssh"]


### PR DESCRIPTION
git diff で末尾空白の除去が見えにくいので設定。
(空白の変更が目視できるようになる)

-b や -w も同時に使えるので邪魔にはならない（はず）