### PR TITLE
fix: ignore *.nogit.md file

### DIFF
--- a/ignore
+++ b/ignore
@@ -9,6 +9,7 @@ terraform.tfstate.backup
 
 # temporary file
 *.nogit
+*.nogit.md
 
 # ansible-vault password file in repo
 .vault_password


### PR DESCRIPTION
`*.nogit` ファイルを個人用途のローカルファイルとして ignore していたんだけど、
マークダウンで扱いたいファイルができた（`todo.nogit.md`）ので追加

VS Code で拡張子付けちゃうでもよかったんだけど、一概にマークダウンとも限らないので
とりあえず正しく扱うことにした。