### PR TITLE
fix: git ignore __*

### DIFF
--- a/ignore
+++ b/ignore
@@ -10,7 +10,7 @@ terraform.tfstate.backup
 # temporary file
 *.nogit
 *.nogit.md
-__*__.md
+__*
 
 # ansible-vault password file in repo
 .vault_password


### PR DESCRIPTION
__*__.md でマークダウンだけ除外にしていたけど、ちょっとしたシェルや
他のファイルにも除外要件がでてきたので、__ で始まるファイルはまとめて除外することにした。

__ で始まるファイルを管理しようとする雑なリポジトリは滅べｗ