### PR TITLE
feat: alias chash is gets current HEAD hash

### DIFF
--- a/config
+++ b/config
@@ -22,6 +22,7 @@
 
 	deleted = log --diff-filter=D --summary
 	restoring = !git checkout $(git rev-list -n 1 HEAD -- "${1:-none}")~1 --
+	chash = rev-parse --short HEAD
 
 [core]
 	# editor = vim +15 +startinsert


### PR DESCRIPTION
current-hash かなんかの名前でどっかに保存してた気がするけどなくなった。。。（ダメ

git show --format='%h' --no-patch を使う方法もあるけど、
これを alias にすると他の show 関係も整理しないといけない気がするので
一旦 rev-parse で。 bash の alias.cr にも使ってるしね。