### PR TITLE
fix: remove --all option from plog alias

### DIFF
--- a/config
+++ b/config
@@ -18,7 +18,7 @@
 
 	# options
 	alias  = !git config --get-regexp 'alias\\.' | sed 's/alias\\.\\([^ ]*\\) \\(.*\\)/\\1\\\t => \\2/' | sort
-	plog   = log --pretty=format:'%C(yellow)%h %C(green)%cd %C(reset)%s %C(red)%d %C(cyan)[%an]' --date=format-local:'%t%Y/%m/%d %H:%M'  --all --graph
+	plog   = log --pretty=format:'%C(yellow)%h %C(green)%cd %C(reset)%s %C(red)%d %C(cyan)[%an]' --date=format-local:'%t%Y/%m/%d %H:%M' --graph
 
 	deleted = log --diff-filter=D --summary
 	restoring = !git checkout $(git rev-list -n 1 HEAD -- "${1:-none}")~1 --


### PR DESCRIPTION
一人で作業している時は特に問題ないんだけど、職場で多数の人がいじってるリポジトリに
--all をデフォルトにしていると見にくいので外すことにした。

これによってブランチ指定が使えるようになるので、 `--first-parent` などと組み合わせて使いやすくできる。はず。

bash alias に影響が出るので別途対応する