### PR TITLE
fix: gitignore z.tfstate

### DIFF
--- a/ignore
+++ b/ignore
@@ -1,10 +1,6 @@
 .DS_Store
 .env
 .envrc
-.terraform/
-.terraformrc
-terraform.tfstate
-terraform.tfstate.backup
 *.swp
 
 # temporary file
@@ -18,3 +14,10 @@ __*
 # for act(github actions localy)
 .act.secrets
 .act.env
+
+# terraform
+.terraform/
+.terraformrc
+terraform.tfstate
+terraform.tfstate.backup
+z.tfstate


### PR DESCRIPTION
terraform 用の gitignore をコメント付きに移動。
個人的によく使う tf state pull のリダイレクト先の z.tfstate を間違って追加しないようにする。